### PR TITLE
Fixes #36 - contentType attribute being ignored.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -109,7 +109,7 @@ element.
        * and a `Content-Type` header is specified in the `headers` attribute,
        * the `headers` attribute value will take precedence.
        */
-      contentType: {
+      contenttype: {
         type: String,
         value: 'application/x-www-form-urlencoded'
       },
@@ -265,7 +265,7 @@ element.
 
     observers: [
       'requestOptionsChanged(url, method, params, headers,' +
-        'contentType, body, sync, handleAs, withCredentials, auto)'
+        'contenttype, body, sync, handleAs, withCredentials, auto)'
     ],
 
     get queryString () {
@@ -299,7 +299,7 @@ element.
 
     get requestHeaders() {
       var headers = {
-        'content-type': this.contentType
+        'content-type': this.contenttype
       };
       var header;
 


### PR DESCRIPTION
As of 1.0.0, iron-ajax expects camelCase attribute but the element is parsed with lowercase attribute names, thus ignoring any setting on contentType.

Changing the attribute expected name to contenttype (lowercase) fixed the issue, even when using contentType in the element.